### PR TITLE
fix(auth): deduplica LegacyId do Mongo e distingue erros de login

### DIFF
--- a/LimpidusMongoDB.API/Controllers/v1/AuthController.cs
+++ b/LimpidusMongoDB.API/Controllers/v1/AuthController.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using LimpidusMongoDB.Application.Auth;
 using LimpidusMongoDB.Application.Contracts.Requests;
 using LimpidusMongoDB.Application.Contracts.Responses;
 using LimpidusMongoDB.Application.Services.Interfaces;
@@ -23,13 +24,25 @@ namespace LimpidusMongoDB.Api.Controllers.v1
         [SwaggerResponse((int)HttpStatusCode.OK, type: typeof(LoginResponse))]
         [SwaggerResponse((int)HttpStatusCode.BadRequest)]
         [SwaggerResponse((int)HttpStatusCode.Unauthorized)]
+        [SwaggerResponse((int)HttpStatusCode.InternalServerError)]
+        [SwaggerResponse((int)HttpStatusCode.ServiceUnavailable)]
         public async Task<IActionResult> Login([FromBody] LoginRequest request, CancellationToken cancellationToken)
         {
             var result = await _authService.LoginAsync(request, cancellationToken);
-            if (!result.Success)
-                return Unauthorized(result);
+            if (result.Success)
+                return Ok(result);
 
-            return Ok(result);
+            // Só credencial inválida é 401; indisponibilidade de SQL/Mongo não pode
+            // se passar por erro de senha.
+            var status = result.Code switch
+            {
+                AuthErrorCodes.InvalidRequest => HttpStatusCode.BadRequest,
+                AuthErrorCodes.ServiceUnavailable => HttpStatusCode.ServiceUnavailable,
+                AuthErrorCodes.Unexpected => HttpStatusCode.InternalServerError,
+                _ => HttpStatusCode.Unauthorized
+            };
+
+            return StatusCode((int)status, result);
         }
 
         /// <summary>

--- a/LimpidusMongoDB.Application/Auth/AuthRoles.cs
+++ b/LimpidusMongoDB.Application/Auth/AuthRoles.cs
@@ -33,4 +33,35 @@ namespace LimpidusMongoDB.Application.Auth
         public const string Franqueado = "franqueado";
         public const string Project = "project";
     }
+
+    /// <summary>
+    /// Códigos estáveis de falha de autenticação. O front usa o código (não a mensagem)
+    /// para escolher o texto traduzido; a mensagem serve como fallback seguro.
+    /// </summary>
+    public static class AuthErrorCodes
+    {
+        /// <summary>Requisição malformada (campos obrigatórios ausentes, type inválido). HTTP 400.</summary>
+        public const string InvalidRequest = "invalid_request";
+
+        /// <summary>Login/senha não conferem. HTTP 401.</summary>
+        public const string InvalidCredentials = "invalid_credentials";
+
+        /// <summary>SQL/Mongo/configuração indisponível. HTTP 503.</summary>
+        public const string ServiceUnavailable = "auth_service_unavailable";
+
+        /// <summary>Qualquer outra falha não prevista. HTTP 500.</summary>
+        public const string Unexpected = "unexpected_error";
+    }
+
+    /// <summary>
+    /// Mensagens devolvidas ao usuário final. Nunca incluem detalhe de infraestrutura.
+    /// </summary>
+    public static class AuthErrorMessages
+    {
+        public const string InvalidRequest = "Login e senha são obrigatórios.";
+        public const string InvalidLoginType = "Tipo de login inválido. Use auto, franqueado ou project.";
+        public const string InvalidCredentials = "Usuário ou senha inválidos.";
+        public const string ServiceUnavailable = "Não foi possível acessar o serviço de autenticação. Tente novamente em alguns instantes.";
+        public const string Unexpected = "Não foi possível concluir o login. Tente novamente.";
+    }
 }

--- a/LimpidusMongoDB.Application/Contracts/Result.cs
+++ b/LimpidusMongoDB.Application/Contracts/Result.cs
@@ -1,4 +1,6 @@
-﻿namespace LimpidusMongoDB.Application.Contracts
+﻿using System.Text.Json.Serialization;
+
+namespace LimpidusMongoDB.Application.Contracts
 {
     public class Result<T>
     {
@@ -6,11 +8,19 @@
         public T Data { get; set; }
         public string Message { get; set; }
 
-        public Result(bool success, string message, T data)
+        /// <summary>
+        /// Código estável de erro para o cliente decidir o tratamento/tradução.
+        /// Omitido do JSON quando nulo para não alterar contratos existentes.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string Code { get; set; }
+
+        public Result(bool success, string message, T data, string code = null)
         {
             Success = success;
             Message = message;
             Data = data;
+            Code = code;
         }
 
         public static Result<T> Ok(string message = null, T data = default)
@@ -18,26 +28,27 @@
             return new Result<T>(true, message, data);
         }
 
-        public static Result<T> Error(string message)
+        public static Result<T> Error(string message, string code = null)
         {
-            return new Result<T>(false, message, default);
+            return new Result<T>(false, message, default, code);
         }
     }
 
     public class Result : Result<object>
     {
-        public Result(bool success, string message, object data) : base(success, message, data)
+        public Result(bool success, string message, object data, string code = null)
+            : base(success, message, data, code)
         {
         }
 
-        public static Result Ok(string message = null, dynamic data = null)
+        public new static Result Ok(string message = null, dynamic data = null)
         {
             return new Result(true, message, data);
         }
 
-        public static Result Error(string message)
+        public new static Result Error(string message, string code = null)
         {
-            return new Result(false, message, default);
+            return new Result(false, message, default, code);
         }
     }
 }

--- a/LimpidusMongoDB.Application/Services/AuthService.cs
+++ b/LimpidusMongoDB.Application/Services/AuthService.cs
@@ -6,6 +6,8 @@ using LimpidusMongoDB.Application.Data.Entities;
 using LimpidusMongoDB.Application.Data.Repositories.Interfaces;
 using LimpidusMongoDB.Application.Helpers;
 using LimpidusMongoDB.Application.Services.Interfaces;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace LimpidusMongoDB.Application.Services
@@ -15,45 +17,76 @@ namespace LimpidusMongoDB.Application.Services
         private readonly ISqlAuthDataAccess _sqlAuth;
         private readonly IJwtTokenService _jwtTokenService;
         private readonly IProjectRepository _projectRepository;
+        private readonly ILogger<AuthService> _logger;
 
         public AuthService(
             ISqlAuthDataAccess sqlAuth,
             IJwtTokenService jwtTokenService,
-            IProjectRepository projectRepository)
+            IProjectRepository projectRepository,
+            ILogger<AuthService> logger)
         {
             _sqlAuth = sqlAuth;
             _jwtTokenService = jwtTokenService;
             _projectRepository = projectRepository;
+            _logger = logger;
         }
 
         public async Task<Result> LoginAsync(LoginRequest request, CancellationToken cancellationToken = default)
         {
             if (request == null || string.IsNullOrWhiteSpace(request.Login) || string.IsNullOrWhiteSpace(request.Password))
-                return Result.Error("Login e senha são obrigatórios.");
+                return Result.Error(AuthErrorMessages.InvalidRequest, AuthErrorCodes.InvalidRequest);
 
             var type = (request.Type ?? AuthLoginTypes.Auto).Trim().ToLowerInvariant();
             if (string.IsNullOrEmpty(type))
                 type = AuthLoginTypes.Auto;
 
+            var login = request.Login.Trim();
+
             try
             {
                 return type switch
                 {
-                    AuthLoginTypes.Auto => await LoginAutoAsync(request.Login.Trim(), request.Password, cancellationToken),
-                    AuthLoginTypes.Franqueado => await LoginFranqueadoAsync(request.Login.Trim(), request.Password, cancellationToken),
-                    AuthLoginTypes.Project => await LoginProjectAsync(request.Login.Trim(), request.Password, cancellationToken),
-                    _ => Result.Error("Tipo de login invalido. Use auto, franqueado ou project.")
+                    AuthLoginTypes.Auto => await LoginAutoAsync(login, request.Password, cancellationToken),
+                    AuthLoginTypes.Franqueado => await LoginFranqueadoAsync(login, request.Password, cancellationToken),
+                    AuthLoginTypes.Project => await LoginProjectAsync(login, request.Password, cancellationToken),
+                    _ => Result.Error(AuthErrorMessages.InvalidLoginType, AuthErrorCodes.InvalidRequest)
                 };
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            // Configuração ausente (ex.: ConnectionStrings:SqlServerDB) — detalhe fica só no log.
             catch (InvalidOperationException ex)
             {
-                return Result.Error(ex.Message);
+                _logger.LogError(ex, "Login '{Login}': configuração de autenticação inválida.", login);
+                return Result.Error(AuthErrorMessages.ServiceUnavailable, AuthErrorCodes.ServiceUnavailable);
             }
-            catch (Exception)
+            catch (Exception ex) when (IsInfrastructureFailure(ex))
             {
-                return Result.Error("Falha ao autenticar. Verifique a conexão SQL / configuração.");
+                _logger.LogError(ex, "Login '{Login}': falha de infraestrutura (SQL/Mongo).", login);
+                return Result.Error(AuthErrorMessages.ServiceUnavailable, AuthErrorCodes.ServiceUnavailable);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Login '{Login}': falha inesperada.", login);
+                return Result.Error(AuthErrorMessages.Unexpected, AuthErrorCodes.Unexpected);
             }
         }
+
+        /// <summary>
+        /// Falhas de dependência externa (banco indisponível, timeout, rede) viram 503;
+        /// qualquer outra coisa é bug nosso e vira 500.
+        /// </summary>
+        private static bool IsInfrastructureFailure(Exception ex) => ex switch
+        {
+            SqlException => true,
+            TimeoutException => true,
+            MongoException => true,
+            System.Net.Sockets.SocketException => true,
+            System.Data.Common.DbException => true,
+            _ => false
+        };
 
 
         private async Task<Result> LoginAutoAsync(string login, string password, CancellationToken cancellationToken)
@@ -70,7 +103,7 @@ namespace LimpidusMongoDB.Application.Services
             var hash = Md5Hasher.HashHex(password);
             var franqueado = await _sqlAuth.ValidateFranqueadoAsync(login, hash, cancellationToken);
             if (franqueado == null)
-                return Result.Error("Usuário ou senha inválidos.");
+                return Result.Error(AuthErrorMessages.InvalidCredentials, AuthErrorCodes.InvalidCredentials);
 
             var isAdmin = await _sqlAuth.IsAdminAsync(franqueado.Id, cancellationToken);
 
@@ -152,15 +185,15 @@ namespace LimpidusMongoDB.Application.Services
             var mongoProjects = await _projectRepository.FindAllAsync();
             if (mongoProjects != null && mongoProjects.Any())
             {
-                return mongoProjects
-                    .OrderBy(p => p.Level == 3 ? 0 : 1)
-                    .ThenBy(p => p.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                return DeduplicateByLegacyId(mongoProjects)
                     .Select(p => new AllowedProjectResponse
                     {
                         Id = p.LegacyId,
                         Name = p.Name ?? string.Empty,
                         Level = p.Level
                     })
+                    .OrderBy(p => p.Level == 3 ? 0 : 1)
+                    .ThenBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
                     .ToList();
             }
 
@@ -181,7 +214,7 @@ namespace LimpidusMongoDB.Application.Services
             if (mongoProjects == null || !mongoProjects.Any())
                 return sqlProjects;
 
-            var mongoById = mongoProjects.ToDictionary(p => p.LegacyId);
+            var mongoById = DeduplicateByLegacyId(mongoProjects).ToDictionary(p => p.LegacyId);
             return sqlProjects
                 .Where(p => mongoById.ContainsKey(p.Id))
                 .Select(p => new AllowedProjectResponse
@@ -191,9 +224,24 @@ namespace LimpidusMongoDB.Application.Services
                     // Preferência Mongo (fonte do Clean Check); SQL já traz NIVEL_PROJETO como fallback.
                     Level = mongoById[p.Id].Level != 0 ? mongoById[p.Id].Level : p.Level
                 })
+                .GroupBy(p => p.Id)
+                .Select(g => g.First())
                 .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
+
+        /// <summary>
+        /// O Mongo tem projetos distintos compartilhando o mesmo LegacyId (ex.: backups e
+        /// versões N2/N3 do mesmo WORK_HEADER_ID). Mantém um por LegacyId, preferindo o de
+        /// maior nível — indexar direto por LegacyId quebraria com chave duplicada.
+        /// </summary>
+        private static IEnumerable<ProjectEntity> DeduplicateByLegacyId(IEnumerable<ProjectEntity> projects) =>
+            projects
+                .GroupBy(p => p.LegacyId)
+                .Select(g => g
+                    .OrderByDescending(p => p.Level)
+                    .ThenBy(p => p.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                    .First());
 
         /// <summary>
         /// Preferência: projeto N3 explícito no nome (ex. Cardoso CC N3), senão o primeiro da lista
@@ -214,7 +262,7 @@ namespace LimpidusMongoDB.Application.Services
         {
             var project = await _sqlAuth.ValidateProjectLoginAsync(login, password, cancellationToken);
             if (project == null)
-                return Result.Error("Usuário ou senha inválidos.");
+                return Result.Error(AuthErrorMessages.InvalidCredentials, AuthErrorCodes.InvalidCredentials);
 
             var mongoProject = await _projectRepository.FindOneAsync(
                 Builders<ProjectEntity>.Filter.Eq(x => x.LegacyId, project.WorkHeaderId),


### PR DESCRIPTION
Login de Consultor/Franqueado quebrava com ArgumentException ao indexar projetos Mongo por LegacyId duplicado (ex.: backups N2/N3 do mesmo WORK_HEADER_ID). A falha era engolida pelo catch genérico e devolvida como 401 de SQL.

Deduplica por LegacyId (preferindo maior Level) e classifica falhas: invalid_credentials → 401, auth_service_unavailable → 503, unexpected → 500, sem expor detalhes sensíveis ao cliente.