### PR TITLE
fix(history): deduplica execuções repetidas e resolve Project canónico

### DIFF
--- a/LimpidusMongoDB.Application/Helpers/HistoryDeduper.cs
+++ b/LimpidusMongoDB.Application/Helpers/HistoryDeduper.cs
@@ -1,0 +1,86 @@
+using LimpidusMongoDB.Application.Contracts.Requests;
+using LimpidusMongoDB.Application.Data.Entities;
+
+namespace LimpidusMongoDB.Application.Helpers
+{
+    /// <summary>
+    /// Deduplicação de execuções de histórico (double-tap / reenvios).
+    /// Alinhada a <c>HistoryService.SaveAsync</c> e <c>scripts/mongo/dedupe-history.mongosh.js</c>.
+    /// </summary>
+    public static class HistoryDeduper
+    {
+        /// <summary>
+        /// Mantém um documento por chave de negócio (o de menor <c>_id</c> = inserção mais antiga).
+        /// </summary>
+        public static IReadOnlyList<HistoryEntity> Deduplicate(IEnumerable<HistoryEntity> histories)
+        {
+            var list = histories?.ToList() ?? new List<HistoryEntity>();
+            if (list.Count <= 1)
+                return list;
+
+            return list
+                .GroupBy(DedupeKey)
+                .Select(g => g.OrderBy(x => x.Id.ToString(), StringComparer.Ordinal).First())
+                .ToList();
+        }
+
+        public static string DedupeKey(HistoryEntity entity) =>
+            string.Join(
+                "|",
+                entity.ProjectId.ToString(),
+                entity.EmployeeId ?? string.Empty,
+                entity.AreaTaskId ?? string.Empty,
+                TruncateToUnixSeconds(entity.EndDate).ToString(),
+                NormalizeJustification(entity.Justification),
+                ItemsFingerprintFromEntity(entity.Items));
+
+        public static bool IsDuplicateSubmission(HistoryEntity existing, HistoryRequest incoming)
+        {
+            if (existing.ProjectId != incoming.ProjectId)
+                return false;
+            if (!string.Equals(existing.EmployeeId, incoming.EmployeeId, StringComparison.Ordinal))
+                return false;
+            if (!string.Equals(existing.AreaTaskId, incoming.AreaTaskId, StringComparison.Ordinal))
+                return false;
+            if (Math.Abs((existing.EndDate - incoming.EndDate).TotalSeconds) > 5)
+                return false;
+            if (!string.Equals(NormalizeJustification(existing.Justification), NormalizeJustification(incoming.Justification), StringComparison.Ordinal))
+                return false;
+            return string.Equals(
+                ItemsFingerprintFromEntity(existing.Items),
+                ItemsFingerprintFromRequest(incoming.Items),
+                StringComparison.Ordinal);
+        }
+
+        public static string NormalizeJustification(HistoryJustificationEntity? j) =>
+            j == null ? "\u001f" : $"{j.Information ?? string.Empty}\u001f{j.Reason ?? string.Empty}";
+
+        public static string NormalizeJustification(JustificationRequest? j) =>
+            j == null ? "\u001f" : $"{j.Information ?? string.Empty}\u001f{j.Reason ?? string.Empty}";
+
+        public static string ItemsFingerprintFromEntity(IEnumerable<HistoryItemEntity>? items) =>
+            string.Join(
+                "|",
+                (items ?? Enumerable.Empty<HistoryItemEntity>())
+                    .Select(x => $"{x.Id}\u001f{x.Performed}\u001f{x.OrderBy?.ToString() ?? string.Empty}")
+                    .OrderBy(x => x, StringComparer.Ordinal));
+
+        public static string ItemsFingerprintFromRequest(IEnumerable<HistoryItemRequest>? items) =>
+            string.Join(
+                "|",
+                (items ?? Enumerable.Empty<HistoryItemRequest>())
+                    .Select(x => $"{x.Id}\u001f{x.Performed}\u001f{x.OrderBy?.ToString() ?? string.Empty}")
+                    .OrderBy(x => x, StringComparer.Ordinal));
+
+        private static long TruncateToUnixSeconds(DateTime value)
+        {
+            var utc = value.Kind switch
+            {
+                DateTimeKind.Utc => value,
+                DateTimeKind.Local => value.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            };
+            return new DateTimeOffset(utc).ToUnixTimeSeconds();
+        }
+    }
+}

--- a/LimpidusMongoDB.Application/Helpers/ProjectLegacyResolver.cs
+++ b/LimpidusMongoDB.Application/Helpers/ProjectLegacyResolver.cs
@@ -1,0 +1,28 @@
+using LimpidusMongoDB.Application.Data.Entities;
+
+namespace LimpidusMongoDB.Application.Helpers
+{
+    /// <summary>
+    /// O Mongo pode ter vários <see cref="ProjectEntity"/> com o mesmo <c>LegacyId</c>
+    /// (backups / versões N1 vs N2/N3). Preferimos o de maior Level (e mais recente).
+    /// </summary>
+    public static class ProjectLegacyResolver
+    {
+        public static ProjectEntity? PreferCanonical(IEnumerable<ProjectEntity>? projects)
+        {
+            if (projects == null)
+                return null;
+
+            return projects
+                .OrderByDescending(p => p.Level)
+                .ThenByDescending(p => p.UpdateDate ?? p.CreatedDate)
+                .ThenBy(p => p.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+        }
+
+        public static IEnumerable<ProjectEntity> DeduplicateByLegacyId(IEnumerable<ProjectEntity> projects) =>
+            projects
+                .GroupBy(p => p.LegacyId)
+                .Select(g => PreferCanonical(g)!);
+    }
+}

--- a/LimpidusMongoDB.Application/Services/AuthService.cs
+++ b/LimpidusMongoDB.Application/Services/AuthService.cs
@@ -185,7 +185,7 @@ namespace LimpidusMongoDB.Application.Services
             var mongoProjects = await _projectRepository.FindAllAsync();
             if (mongoProjects != null && mongoProjects.Any())
             {
-                return DeduplicateByLegacyId(mongoProjects)
+                return ProjectLegacyResolver.DeduplicateByLegacyId(mongoProjects)
                     .Select(p => new AllowedProjectResponse
                     {
                         Id = p.LegacyId,
@@ -214,7 +214,7 @@ namespace LimpidusMongoDB.Application.Services
             if (mongoProjects == null || !mongoProjects.Any())
                 return sqlProjects;
 
-            var mongoById = DeduplicateByLegacyId(mongoProjects).ToDictionary(p => p.LegacyId);
+            var mongoById = ProjectLegacyResolver.DeduplicateByLegacyId(mongoProjects).ToDictionary(p => p.LegacyId);
             return sqlProjects
                 .Where(p => mongoById.ContainsKey(p.Id))
                 .Select(p => new AllowedProjectResponse
@@ -229,19 +229,6 @@ namespace LimpidusMongoDB.Application.Services
                 .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
-
-        /// <summary>
-        /// O Mongo tem projetos distintos compartilhando o mesmo LegacyId (ex.: backups e
-        /// versões N2/N3 do mesmo WORK_HEADER_ID). Mantém um por LegacyId, preferindo o de
-        /// maior nível — indexar direto por LegacyId quebraria com chave duplicada.
-        /// </summary>
-        private static IEnumerable<ProjectEntity> DeduplicateByLegacyId(IEnumerable<ProjectEntity> projects) =>
-            projects
-                .GroupBy(p => p.LegacyId)
-                .Select(g => g
-                    .OrderByDescending(p => p.Level)
-                    .ThenBy(p => p.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
-                    .First());
 
         /// <summary>
         /// Preferência: projeto N3 explícito no nome (ex. Cardoso CC N3), senão o primeiro da lista
@@ -264,9 +251,10 @@ namespace LimpidusMongoDB.Application.Services
             if (project == null)
                 return Result.Error(AuthErrorMessages.InvalidCredentials, AuthErrorCodes.InvalidCredentials);
 
-            var mongoProject = await _projectRepository.FindOneAsync(
+            var mongoProjects = await _projectRepository.FindAsync(
                 Builders<ProjectEntity>.Filter.Eq(x => x.LegacyId, project.WorkHeaderId),
                 cancellationToken);
+            var mongoProject = ProjectLegacyResolver.PreferCanonical(mongoProjects);
             var level = mongoProject?.Level ?? project.NivelProjeto;
 
             var allowed = new[]

--- a/LimpidusMongoDB.Application/Services/HistoryService.cs
+++ b/LimpidusMongoDB.Application/Services/HistoryService.cs
@@ -39,7 +39,8 @@ namespace LimpidusMongoDB.Application.Services
             {
                 var mongoFilter = Builders<HistoryEntity>.Filter;
                 var filter = mongoFilter.Eq(x => x.ProjectId, legacyProjectId) & mongoFilter.Eq(x => x.EmployeeId, employeeId);
-                var histories = await _historyRepository.FindAsync(filter, cancellationToken);
+                var histories = HistoryDeduper.Deduplicate(
+                    await _historyRepository.FindAsync(filter, cancellationToken));
 
                 var responseList = histories.Select(x => new HistoryResponse(x));
 
@@ -74,14 +75,19 @@ namespace LimpidusMongoDB.Application.Services
                 & (!query.Status.HasValue ? mongoFilter.Empty :
                     (query.Status.Value ? mongoFilter.Where(y => y.Justification.Information == null) : mongoFilter.Where(y => y.Justification.Information != null)));
 
-                var histories = await _historyRepository.FindAsync(filter, cancellationToken);
+                // History.ProjectId é o LegacyId (int), não ObjectId — sem join em Project.
+                // Duplicatas na UI vêm de documentos repetidos (double-tap); dedupe na leitura.
+                var histories = HistoryDeduper.Deduplicate(
+                    await _historyRepository.FindAsync(filter, cancellationToken));
 
                 var responseList = histories.Select(x => new HistoryResponse(x)).ToList();
 
                 // N2/N3: detalhe de atividades no painel Detalhes do relatório web. N1: payload sem Items.
-                var project = await _projectRepository.FindOneAsync(
+                // Com LegacyId duplicado (backup N1 + N2/N3), preferir o projeto canónico (maior Level).
+                var projects = await _projectRepository.FindAsync(
                     Builders<ProjectEntity>.Filter.Eq(x => x.LegacyId, legacyProjectId),
                     cancellationToken);
+                var project = ProjectLegacyResolver.PreferCanonical(projects);
                 var includeActivityDetails = project != null && project.Level >= 2;
 
                 var results = responseList.Select(x => new HistoryAuditResponse()
@@ -192,7 +198,7 @@ namespace LimpidusMongoDB.Application.Services
                             & Builders<HistoryEntity>.Filter.Lte(x => x.EndDate, request.EndDate.AddSeconds(15));
 
                         var candidates = await _historyRepository.FindAsync(filterDup, cancellationToken);
-                        if (candidates.Any(c => IsDuplicateHistorySubmission(c, request)))
+                        if (candidates.Any(c => HistoryDeduper.IsDuplicateSubmission(c, request)))
                             continue;
                     }
 
@@ -233,46 +239,5 @@ namespace LimpidusMongoDB.Application.Services
                 return Result.Error(ApplicationErrors.Application_Error_General.Description());
             }
         }
-
-        /// <summary>
-        /// Mesma ideia do script <c>scripts/mongo/dedupe-history.mongosh.js</c>: mesmo envio (área, fim, itens, justificativa).
-        /// </summary>
-        private static bool IsDuplicateHistorySubmission(HistoryEntity existing, HistoryRequest incoming)
-        {
-            if (existing.ProjectId != incoming.ProjectId)
-                return false;
-            if (!string.Equals(existing.EmployeeId, incoming.EmployeeId, StringComparison.Ordinal))
-                return false;
-            if (!string.Equals(existing.AreaTaskId, incoming.AreaTaskId, StringComparison.Ordinal))
-                return false;
-            if (Math.Abs((existing.EndDate - incoming.EndDate).TotalSeconds) > 5)
-                return false;
-            if (!string.Equals(NormalizeJustification(existing.Justification), NormalizeJustification(incoming.Justification), StringComparison.Ordinal))
-                return false;
-            return string.Equals(
-                ItemsFingerprintFromEntity(existing.Items),
-                ItemsFingerprintFromRequest(incoming.Items),
-                StringComparison.Ordinal);
-        }
-
-        private static string NormalizeJustification(HistoryJustificationEntity? j) =>
-            j == null ? "\u001f" : $"{j.Information ?? string.Empty}\u001f{j.Reason ?? string.Empty}";
-
-        private static string NormalizeJustification(JustificationRequest? j) =>
-            j == null ? "\u001f" : $"{j.Information ?? string.Empty}\u001f{j.Reason ?? string.Empty}";
-
-        private static string ItemsFingerprintFromEntity(IEnumerable<HistoryItemEntity>? items) =>
-            string.Join(
-                "|",
-                (items ?? Enumerable.Empty<HistoryItemEntity>())
-                    .Select(x => $"{x.Id}\u001f{x.Performed}\u001f{x.OrderBy?.ToString() ?? string.Empty}")
-                    .OrderBy(x => x, StringComparer.Ordinal));
-
-        private static string ItemsFingerprintFromRequest(IEnumerable<HistoryItemRequest>? items) =>
-            string.Join(
-                "|",
-                (items ?? Enumerable.Empty<HistoryItemRequest>())
-                    .Select(x => $"{x.Id}\u001f{x.Performed}\u001f{x.OrderBy?.ToString() ?? string.Empty}")
-                    .OrderBy(x => x, StringComparer.Ordinal));
     }
 }

--- a/LimpidusMongoDB.Application/Services/ProjectService.cs
+++ b/LimpidusMongoDB.Application/Services/ProjectService.cs
@@ -32,7 +32,7 @@ namespace LimpidusMongoDB.Application.Services
 
                 var projectResponseList = new List<ProjectResponse>();
 
-                foreach (var project in projects)
+                foreach (var project in ProjectLegacyResolver.DeduplicateByLegacyId(projects))
                     projectResponseList.Add(await GetProjectDetail(project));
 
                 return Result.Ok(data: projectResponseList);
@@ -47,7 +47,9 @@ namespace LimpidusMongoDB.Application.Services
         {
             try
             {
-                var project = await _projectRepository.FindOneAsync(Builders<ProjectEntity>.Filter.Eq("legacyId", legacyId));
+                var projects = await _projectRepository.FindAsync(
+                    Builders<ProjectEntity>.Filter.Eq(x => x.LegacyId, legacyId));
+                var project = ProjectLegacyResolver.PreferCanonical(projects);
                 if (project == null)
                     return Result.Error(ProjectErrors.Project_Error_NotFound.Description());
 
@@ -122,9 +124,10 @@ namespace LimpidusMongoDB.Application.Services
 
         public async Task<int?> GetMaxHistoryRangeDaysAsync(int legacyId, CancellationToken cancellationToken = default)
         {
-            var project = await _projectRepository.FindOneAsync(
+            var projects = await _projectRepository.FindAsync(
                 Builders<ProjectEntity>.Filter.Eq(x => x.LegacyId, legacyId),
                 cancellationToken);
+            var project = ProjectLegacyResolver.PreferCanonical(projects);
             return project?.MaxHistoryRangeDays;
         }
 
@@ -144,15 +147,17 @@ namespace LimpidusMongoDB.Application.Services
                 if (maxHistoryRangeDays is <= 0)
                     return Result.Error("maxHistoryRangeDays deve ser um inteiro positivo, ou null para o default.");
 
-                var filter = Builders<ProjectEntity>.Filter.Eq(x => x.LegacyId, legacyId);
-                var project = await _projectRepository.FindOneAsync(filter, cancellationToken);
+                var projects = await _projectRepository.FindAsync(
+                    Builders<ProjectEntity>.Filter.Eq(x => x.LegacyId, legacyId),
+                    cancellationToken);
+                var project = ProjectLegacyResolver.PreferCanonical(projects);
                 if (project == null)
                     return Result.Error(ProjectErrors.Project_Error_NotFound.Description());
 
                 var update = BaseEntity.UpdateDateDefinition(
                     Builders<ProjectEntity>.Update.Set(x => x.MaxHistoryRangeDays, maxHistoryRangeDays));
 
-                await _projectRepository.UpdateOneAsync(filter, update, cancellationToken);
+                await _projectRepository.UpdateOneAsync(project.Id.ToString(), update, cancellationToken);
                 return Result.Ok(data: new HistoryRangeResponse
                 {
                     LegacyId = legacyId,

--- a/LimpidusMongoDB.Tests/Helpers/HistoryDeduperTests.cs
+++ b/LimpidusMongoDB.Tests/Helpers/HistoryDeduperTests.cs
@@ -1,0 +1,49 @@
+using LimpidusMongoDB.Application.Data.Entities;
+using LimpidusMongoDB.Application.Helpers;
+
+namespace LimpidusMongoDB.Tests.Helpers;
+
+public class HistoryDeduperTests
+{
+    [Fact]
+    public void Deduplicate_keeps_oldest_of_identical_submissions()
+    {
+        var end = new DateTime(2026, 5, 1, 12, 30, 15, DateTimeKind.Utc);
+        var older = MakeHistory("aaaaaaaaaaaaaaaaaaaaaaaa", end, "area-1", "emp-1");
+        var newer = MakeHistory("bbbbbbbbbbbbbbbbbbbbbbbb", end, "area-1", "emp-1");
+        var other = MakeHistory("cccccccccccccccccccccccc", end, "area-2", "emp-1");
+
+        var result = HistoryDeduper.Deduplicate(new[] { newer, older, other });
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, h => h.Id == older.Id);
+        Assert.Contains(result, h => h.Id == other.Id);
+        Assert.DoesNotContain(result, h => h.Id == newer.Id);
+    }
+
+    [Fact]
+    public void PreferCanonical_picks_highest_level()
+    {
+        var n1 = new ProjectEntity { LegacyId = 4700, Name = "BACKUP", Level = 1 };
+        var n2 = new ProjectEntity { LegacyId = 4700, Name = "CC N2", Level = 2 };
+
+        var picked = ProjectLegacyResolver.PreferCanonical(new[] { n1, n2 });
+
+        Assert.Same(n2, picked);
+    }
+
+    private static HistoryEntity MakeHistory(string idHex, DateTime end, string areaId, string employeeId)
+    {
+        var entity = new HistoryEntity
+        {
+            ProjectId = 4698,
+            EmployeeId = employeeId,
+            AreaTaskId = areaId,
+            AreaTaskName = "WC",
+            EndDate = end,
+            Items = Array.Empty<HistoryItemEntity>()
+        };
+        entity.SetObjectId(idHex);
+        return entity;
+    }
+}


### PR DESCRIPTION
Histórico/relatório listava o mesmo envio várias vezes porque a coleção history contém documentos duplicados (double-tap). Dedupe na leitura pela chave de negócio e, com LegacyId repetido no Mongo, preferir o Project de maior Level para Items N2/N3 e overrides.