### PR TITLE
feat(client-access): API de permissões do cliente e filtro de atividades

### DIFF
--- a/LimpidusMongoDB.API/Controllers/v1/HistoryController.cs
+++ b/LimpidusMongoDB.API/Controllers/v1/HistoryController.cs
@@ -81,10 +81,23 @@ namespace LimpidusMongoDB.Api.Controllers.v1
             if (!result.Success)
                 return BadRequest(result);
 
-            if (!_projectAccess.CanSeeSensitiveHistory(User) && result.Data is HistoryListResponse list && list.Data != null)
+            if (result.Data is HistoryListResponse list && list.Data != null)
             {
-                foreach (var row in list.Data)
-                    row.Justification = null;
+                if (_projectAccess.IsProjectViewer(User))
+                {
+                    var access = await _projectService.GetClientAccessAsync(legacyId, cancellationToken);
+                    var settings = access.Success ? access.Data as ClientAccessResponse : null;
+                    HistoryClientViewHelper.ApplyForProjectViewer(
+                        list,
+                        settings?.ShowActivitiesToClient ?? true,
+                        settings?.ClientVisibleActivityItemIds);
+                }
+
+                if (!_projectAccess.CanSeeSensitiveHistory(User))
+                {
+                    foreach (var row in list.Data)
+                        row.Justification = null;
+                }
             }
 
             return Ok(result);

--- a/LimpidusMongoDB.API/Controllers/v1/ProjectController.cs
+++ b/LimpidusMongoDB.API/Controllers/v1/ProjectController.cs
@@ -78,7 +78,10 @@ namespace LimpidusMongoDB.Api.Controllers.v1
             if (!result.Success)
                 return BadRequest(result);
 
-            if (!_projectAccess.IsAdmin(User) && result.Data is IEnumerable<ProjectResponse> projects)
+            // Admin e Consultor: catálogo completo. Franqueado: só a carteira permitida.
+            if (!_projectAccess.IsAdmin(User)
+                && !_projectAccess.IsConsultor(User)
+                && result.Data is IEnumerable<ProjectResponse> projects)
             {
                 var filtered = projects
                     .Where(p => _projectAccess.CanAccessLegacyProject(User, p.LegacyId))
@@ -173,10 +176,10 @@ namespace LimpidusMongoDB.Api.Controllers.v1
         }
 
         /// <summary>
-        /// PUT override do range maximo de historico do ProjectViewer neste projeto (somente Admin).
+        /// PUT override do range maximo de historico do ProjectViewer neste projeto (Admin / Franqueado / Consultor).
         /// Body: <c>{ "maxHistoryRangeDays": 180 }</c> ou <c>null</c> para voltar ao default 90.
         /// </summary>
-        [Authorize(Policy = AuthPolicies.AdminOnly)]
+        [Authorize(Policy = AuthPolicies.CanExportReports)]
         [HttpPut("legacyId/{legacyId}/history-range")]
         [SwaggerResponse((int)HttpStatusCode.OK, type: typeof(HistoryRangeResponse))]
         [SwaggerResponse((int)HttpStatusCode.Forbidden)]
@@ -186,7 +189,12 @@ namespace LimpidusMongoDB.Api.Controllers.v1
             [FromBody] SetHistoryRangeRequest request,
             CancellationToken cancellationToken)
         {
-            if (!_projectAccess.IsAdmin(User))
+            if (!_projectAccess.CanAccessLegacyProject(User, legacyId))
+                return Forbid();
+
+            if (!_projectAccess.IsAdmin(User)
+                && !_projectAccess.IsFranqueado(User)
+                && !_projectAccess.IsConsultor(User))
                 return Forbid();
 
             var result = await _projectService.SetMaxHistoryRangeDaysAsync(
@@ -194,6 +202,46 @@ namespace LimpidusMongoDB.Api.Controllers.v1
                 request?.MaxHistoryRangeDays,
                 cancellationToken);
 
+            return result.Success ? Ok(result) : BadRequest(result);
+        }
+
+        /// <summary>
+        /// GET configuração de acesso do cliente (dias + atividades) do projeto.
+        /// </summary>
+        [Authorize(Policy = AuthPolicies.CanExportReports)]
+        [HttpGet("legacyId/{legacyId}/client-access")]
+        [SwaggerResponse((int)HttpStatusCode.OK, type: typeof(ClientAccessResponse))]
+        [SwaggerResponse((int)HttpStatusCode.Forbidden)]
+        [SwaggerResponse((int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> GetClientAccess(
+            [FromRoute] int legacyId,
+            CancellationToken cancellationToken)
+        {
+            if (!CanManageClientAccessForProject(legacyId))
+                return Forbid();
+
+            var result = await _projectService.GetClientAccessAsync(legacyId, cancellationToken);
+            return result.Success ? Ok(result) : BadRequest(result);
+        }
+
+        /// <summary>
+        /// PUT configuração de acesso do cliente (dias, mostrar atividades, quais atividades).
+        /// Admin / Consultor: qualquer projeto. Franqueado: só a própria carteira.
+        /// </summary>
+        [Authorize(Policy = AuthPolicies.CanExportReports)]
+        [HttpPut("legacyId/{legacyId}/client-access")]
+        [SwaggerResponse((int)HttpStatusCode.OK, type: typeof(ClientAccessResponse))]
+        [SwaggerResponse((int)HttpStatusCode.Forbidden)]
+        [SwaggerResponse((int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> SetClientAccess(
+            [FromRoute] int legacyId,
+            [FromBody] SetClientAccessRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (!CanManageClientAccessForProject(legacyId))
+                return Forbid();
+
+            var result = await _projectService.SetClientAccessAsync(legacyId, request, cancellationToken);
             return result.Success ? Ok(result) : BadRequest(result);
         }
 
@@ -428,6 +476,19 @@ namespace LimpidusMongoDB.Api.Controllers.v1
             var result = await _projectService.SaveAsync(request);
 
             return result.Success ? Ok(result) : BadRequest(result);
+        }
+
+        /// <summary>
+        /// Admin/Consultor: qualquer projeto. Franqueado folha: só carteira (ID_DONO + share).
+        /// </summary>
+        private bool CanManageClientAccessForProject(int legacyId)
+        {
+            if (_projectAccess.IsAdmin(User) || _projectAccess.IsConsultor(User))
+                return true;
+
+            // Franqueado folha (IsFranqueado cobre consultor, mas consultor já retornou acima)
+            return _projectAccess.IsFranqueado(User)
+                && _projectAccess.CanAccessLegacyProject(User, legacyId);
         }
     }
 }

--- a/LimpidusMongoDB.Application/Contracts/Requests/SetClientAccessRequest.cs
+++ b/LimpidusMongoDB.Application/Contracts/Requests/SetClientAccessRequest.cs
@@ -1,0 +1,24 @@
+namespace LimpidusMongoDB.Application.Contracts.Requests
+{
+    public class SetClientAccessRequest
+    {
+        /// <summary>Override de dias do ProjectViewer. Null = voltar ao default 90.</summary>
+        public int? MaxHistoryRangeDays { get; set; }
+
+        /// <summary>Se omitido, mantém o valor atual.</summary>
+        public bool? ShowActivitiesToClient { get; set; }
+
+        /// <summary>
+        /// ItemIds visíveis ao cliente. Null = todas.
+        /// Envie lista vazia para nenhuma atividade visível.
+        /// Se omitido (campo ausente via merge), o service trata null como "todas" quando o body envia explicitamente null.
+        /// </summary>
+        public List<string>? ClientVisibleActivityItemIds { get; set; }
+
+        /// <summary>
+        /// Quando true, aplica ClientVisibleActivityItemIds mesmo se null (todas).
+        /// Front sempre envia true ao salvar a seção de atividades.
+        /// </summary>
+        public bool UpdateVisibleActivities { get; set; } = true;
+    }
+}

--- a/LimpidusMongoDB.Application/Contracts/Responses/ClientAccessResponse.cs
+++ b/LimpidusMongoDB.Application/Contracts/Responses/ClientAccessResponse.cs
@@ -1,0 +1,34 @@
+namespace LimpidusMongoDB.Application.Contracts.Responses
+{
+    public class ClientActivityOptionResponse
+    {
+        public string ItemId { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Configuração de acesso do ProjectViewer (cliente) por projeto.
+    /// </summary>
+    public class ClientAccessResponse
+    {
+        public int LegacyId { get; set; }
+        public string ProjectName { get; set; } = string.Empty;
+
+        /// <summary>Override de dias (null = default 90).</summary>
+        public int? MaxHistoryRangeDays { get; set; }
+
+        public int DefaultProjectViewerDays { get; set; }
+
+        /// <summary>Teto efetivo do cliente: override ?? 90.</summary>
+        public int EffectiveMaxDays { get; set; }
+
+        /// <summary>Se o cliente vê atividades no expand do histórico.</summary>
+        public bool ShowActivitiesToClient { get; set; } = true;
+
+        /// <summary>Null = todas as atividades do catálogo.</summary>
+        public List<string>? ClientVisibleActivityItemIds { get; set; }
+
+        /// <summary>Catálogo único de atividades do projeto (AreaActivity items).</summary>
+        public List<ClientActivityOptionResponse> AvailableActivities { get; set; } = new();
+    }
+}

--- a/LimpidusMongoDB.Application/Data/Entities/ProjectEntity.cs
+++ b/LimpidusMongoDB.Application/Data/Entities/ProjectEntity.cs
@@ -21,9 +21,21 @@ namespace LimpidusMongoDB.Application.Data.Entities
 
         /// <summary>
         /// Override do range máximo de histórico para ProjectViewer (dias).
-        /// Null = default 90. Não entra no GetUpdateDefinition (atualizado só via API Admin).
+        /// Null = default 90. Não entra no GetUpdateDefinition (atualizado só via API de acesso do cliente).
         /// </summary>
         public int? MaxHistoryRangeDays { get; set; }
+
+        /// <summary>
+        /// Se o ProjectViewer vê o detalhe de atividades (itens) no histórico.
+        /// Null = true (padrão).
+        /// </summary>
+        public bool? ShowActivitiesToClient { get; set; }
+
+        /// <summary>
+        /// ItemIds de AreaActivity permitidos na visão do cliente.
+        /// Null = todas. Lista vazia = nenhuma (quando ShowActivitiesToClient).
+        /// </summary>
+        public List<string>? ClientVisibleActivityItemIds { get; set; }
 
         public UpdateDefinition<ProjectEntity> GetUpdateDefinition() =>
             Builders<ProjectEntity>.Update

--- a/LimpidusMongoDB.Application/Helpers/HistoryClientViewHelper.cs
+++ b/LimpidusMongoDB.Application/Helpers/HistoryClientViewHelper.cs
@@ -1,0 +1,90 @@
+using LimpidusMongoDB.Application.Contracts.Responses;
+using HistoryListResponse = LimpidusMongoDB.Application.Services.Interfaces.HistoryListResponse;
+using HistoryUserResponse = LimpidusMongoDB.Application.Services.Interfaces.HistoryUserResponse;
+
+namespace LimpidusMongoDB.Application.Helpers
+{
+    /// <summary>
+    /// Regras de visão do histórico para ProjectViewer (cliente).
+    /// </summary>
+    public static class HistoryClientViewHelper
+    {
+        /// <summary>
+        /// Filtra áreas incompletas e aplica permissões de atividades na lista do relatório.
+        /// </summary>
+        public static void ApplyForProjectViewer(
+            HistoryListResponse list,
+            bool showActivities,
+            IReadOnlyCollection<string>? visibleItemIds)
+        {
+            if (list?.Data == null)
+                return;
+
+            var allowed = visibleItemIds == null
+                ? null
+                : new HashSet<string>(
+                    visibleItemIds.Where(id => !string.IsNullOrWhiteSpace(id)),
+                    StringComparer.OrdinalIgnoreCase);
+
+            list.Data = list.Data
+                .Where(IsFullyCompletedForClient)
+                .Select(row => ApplyActivityVisibility(row, showActivities, allowed))
+                .ToList();
+
+            list.Departments = list.Data
+                .Select(x => x.Department)
+                .Where(d => !string.IsNullOrWhiteSpace(d))
+                .OrderBy(x => x)
+                .Distinct()
+                .ToList();
+
+            list.Employees = list.Data
+                .GroupBy(x => x.EmployeeName + " " + x.EmployeeLastName)
+                .Select(g => new HistoryUserResponse
+                {
+                    Name = g.First().EmployeeName,
+                    LastName = g.First().EmployeeLastName
+                })
+                .OrderBy(x => x.Name)
+                .ThenBy(x => x.LastName)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Área só aparece para o cliente se não houver itens ou se todos foram realizados.
+        /// </summary>
+        public static bool IsFullyCompletedForClient(HistoryAuditResponse row)
+        {
+            if (row?.Items == null || row.Items.Count == 0)
+                return true;
+
+            return row.Items.All(i => i.Performed);
+        }
+
+        private static HistoryAuditResponse ApplyActivityVisibility(
+            HistoryAuditResponse row,
+            bool showActivities,
+            HashSet<string>? allowedIds)
+        {
+            if (!showActivities)
+            {
+                row.Items = null;
+                return row;
+            }
+
+            if (row.Items == null)
+                return row;
+
+            if (allowedIds == null)
+                return row;
+
+            row.Items = row.Items
+                .Where(i =>
+                    (!string.IsNullOrWhiteSpace(i.Id) && allowedIds.Contains(i.Id))
+                    || (!string.IsNullOrWhiteSpace(i.Name) && allowedIds.Contains(i.Name)))
+                .ToList();
+
+            return row;
+        }
+    }
+}

--- a/LimpidusMongoDB.Application/Services/Interfaces/IProjectService.cs
+++ b/LimpidusMongoDB.Application/Services/Interfaces/IProjectService.cs
@@ -20,5 +20,9 @@ namespace LimpidusMongoDB.Application.Services.Interfaces
         Task<int> GetEffectiveProjectViewerMaxDaysAsync(int legacyId, CancellationToken cancellationToken = default);
 
         Task<Result> SetMaxHistoryRangeDaysAsync(int legacyId, int? maxHistoryRangeDays, CancellationToken cancellationToken = default);
+
+        Task<Result> GetClientAccessAsync(int legacyId, CancellationToken cancellationToken = default);
+
+        Task<Result> SetClientAccessAsync(int legacyId, SetClientAccessRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/LimpidusMongoDB.Application/Services/ProjectService.cs
+++ b/LimpidusMongoDB.Application/Services/ProjectService.cs
@@ -14,11 +14,16 @@ namespace LimpidusMongoDB.Application.Services
     {
         private readonly IProjectRepository _projectRepository;
         private readonly IEmployeeRepository _employeeRepository;
+        private readonly IAreaActivityRepository _areaActivityRepository;
 
-        public ProjectService(IProjectRepository projectRepository, IEmployeeRepository employeeRepository)
+        public ProjectService(
+            IProjectRepository projectRepository,
+            IEmployeeRepository employeeRepository,
+            IAreaActivityRepository areaActivityRepository)
         {
             _projectRepository = projectRepository;
             _employeeRepository = employeeRepository;
+            _areaActivityRepository = areaActivityRepository;
         }
 
         public async Task<Result> GetAllProjects()
@@ -172,7 +177,124 @@ namespace LimpidusMongoDB.Application.Services
             }
         }
 
+        public async Task<Result> GetClientAccessAsync(int legacyId, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var projects = await _projectRepository.FindAsync(
+                    Builders<ProjectEntity>.Filter.Eq(x => x.LegacyId, legacyId),
+                    cancellationToken);
+                var project = ProjectLegacyResolver.PreferCanonical(projects);
+                if (project == null)
+                    return Result.Error(ProjectErrors.Project_Error_NotFound.Description());
+
+                var available = await BuildAvailableActivitiesAsync(legacyId, cancellationToken);
+                return Result.Ok(data: MapClientAccess(project, available));
+            }
+            catch (Exception)
+            {
+                return Result.Error(ApplicationErrors.Application_Error_General.Description());
+            }
+        }
+
+        public async Task<Result> SetClientAccessAsync(
+            int legacyId,
+            SetClientAccessRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                if (request == null)
+                    return Result.Error("Body inválido.");
+
+                if (request.MaxHistoryRangeDays is <= 0)
+                    return Result.Error("maxHistoryRangeDays deve ser um inteiro positivo, ou null para o default.");
+
+                var projects = await _projectRepository.FindAsync(
+                    Builders<ProjectEntity>.Filter.Eq(x => x.LegacyId, legacyId),
+                    cancellationToken);
+                var project = ProjectLegacyResolver.PreferCanonical(projects);
+                if (project == null)
+                    return Result.Error(ProjectErrors.Project_Error_NotFound.Description());
+
+                var showActivities = request.ShowActivitiesToClient ?? project.ShowActivitiesToClient ?? true;
+                List<string>? visibleIds = project.ClientVisibleActivityItemIds;
+                if (request.UpdateVisibleActivities)
+                {
+                    visibleIds = request.ClientVisibleActivityItemIds?
+                        .Where(id => !string.IsNullOrWhiteSpace(id))
+                        .Select(id => id.Trim())
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToList();
+                }
+
+                var update = BaseEntity.UpdateDateDefinition(
+                    Builders<ProjectEntity>.Update
+                        .Set(x => x.MaxHistoryRangeDays, request.MaxHistoryRangeDays)
+                        .Set(x => x.ShowActivitiesToClient, showActivities)
+                        .Set(x => x.ClientVisibleActivityItemIds, visibleIds));
+
+                await _projectRepository.UpdateOneAsync(project.Id.ToString(), update, cancellationToken);
+
+                project.MaxHistoryRangeDays = request.MaxHistoryRangeDays;
+                project.ShowActivitiesToClient = showActivities;
+                project.ClientVisibleActivityItemIds = visibleIds;
+
+                var available = await BuildAvailableActivitiesAsync(legacyId, cancellationToken);
+                return Result.Ok(data: MapClientAccess(project, available));
+            }
+            catch (Exception)
+            {
+                return Result.Error(ApplicationErrors.Application_Error_General.Description());
+            }
+        }
+
         #region Private methods
+
+        private static ClientAccessResponse MapClientAccess(
+            ProjectEntity project,
+            List<ClientActivityOptionResponse> available)
+        {
+            return new ClientAccessResponse
+            {
+                LegacyId = project.LegacyId,
+                ProjectName = project.Name ?? string.Empty,
+                MaxHistoryRangeDays = project.MaxHistoryRangeDays,
+                DefaultProjectViewerDays = HistoryRangeLimits.ProjectViewerDefaultDays,
+                EffectiveMaxDays = HistoryRangeLimits.EffectiveProjectViewerDays(project.MaxHistoryRangeDays),
+                ShowActivitiesToClient = project.ShowActivitiesToClient ?? true,
+                ClientVisibleActivityItemIds = project.ClientVisibleActivityItemIds,
+                AvailableActivities = available
+            };
+        }
+
+        private async Task<List<ClientActivityOptionResponse>> BuildAvailableActivitiesAsync(
+            int legacyId,
+            CancellationToken cancellationToken)
+        {
+            var areas = await _areaActivityRepository.FindAsync(
+                Builders<AreaActivityEntity>.Filter.Eq(x => x.ProjectId, legacyId),
+                cancellationToken);
+
+            return (areas ?? Enumerable.Empty<AreaActivityEntity>())
+                .SelectMany(a => a.Items ?? Enumerable.Empty<AreaActivityItemEntity>())
+                .Where(i => !string.IsNullOrWhiteSpace(i.ItemId) || !string.IsNullOrWhiteSpace(i.Name))
+                .GroupBy(
+                    i => string.IsNullOrWhiteSpace(i.ItemId) ? i.Name.Trim() : i.ItemId.Trim(),
+                    StringComparer.OrdinalIgnoreCase)
+                .Select(g =>
+                {
+                    var first = g.First();
+                    return new ClientActivityOptionResponse
+                    {
+                        ItemId = string.IsNullOrWhiteSpace(first.ItemId) ? first.Name.Trim() : first.ItemId.Trim(),
+                        Name = first.Name?.Trim() ?? first.ItemId?.Trim() ?? string.Empty
+                    };
+                })
+                .OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
 
         private async Task<ProjectResponse> GetProjectDetail(ProjectEntity projectEntity)
         {


### PR DESCRIPTION
Persiste dias/atividades no projeto, aplica visão do ProjectViewer e libera catálogo completo para Admin/Consultor.